### PR TITLE
Add Docker image build files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
-FROM zapier/python:latest as base
+FROM python:3.8-slim as base
 
-RUN mkdir /build
-WORKDIR /build
+RUN mkdir /install
+WORKDIR /install
 
-COPY . /build/
+COPY ./dist/*.whl /install/
 
-RUN poetry install --no-interaction --no-ansi
-RUN ln -s $(poetry env info -p)/bin/protect-archiver /usr/local/bin/protect-archiver
+RUN pip install *.whl
 
 ENTRYPOINT [ "protect-archiver" ]
 CMD [ "--help" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,18 @@
-FROM python:3.8-slim as base
+FROM zapier/python:latest AS build
+
+RUN mkdir /build
+WORKDIR /build
+
+COPY . /build/
+
+RUN poetry build -f wheel --no-ansi --no-interaction
+
+FROM python:3.8-slim AS base
 
 RUN mkdir /install
 WORKDIR /install
 
-COPY ./dist/*.whl /install/
+COPY --from=build /build/dist/*.whl /install/
 
 RUN pip install *.whl
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM zapier/python:latest as base
+
+RUN mkdir /build
+WORKDIR /build
+
+COPY . /build/
+
+RUN poetry install --no-interaction --no-ansi
+RUN ln -s $(poetry env info -p)/bin/protect-archiver /usr/local/bin/protect-archiver
+
+ENTRYPOINT [ "protect-archiver" ]
+CMD [ "--help" ]
+
+VOLUME [ "/downloads" ]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+NAME   := unifitoolbox/protect-archiver
+TAG    := `git log -1 --pretty=%H`
+IMG    := ${NAME}:${TAG}
+LATEST := ${NAME}:latest
+
+build:
+	@docker build -t ${IMG} .
+	@docker tag ${IMG} ${LATEST}
+
+push:
+	@docker push ${NAME}

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,6 @@ IMG    := ${NAME}:${TAG}
 LATEST := ${NAME}:latest
 
 build:
-	@rm -rf ./dist
-	@poetry build -f wheel --no-ansi --no-interaction
 	@docker build -t ${IMG} .
 	@docker tag ${IMG} ${LATEST}
 

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ IMG    := ${NAME}:${TAG}
 LATEST := ${NAME}:latest
 
 build:
+	@rm -rf ./dist
+	@poetry build -f wheel --no-ansi --no-interaction
 	@docker build -t ${IMG} .
 	@docker tag ${IMG} ${LATEST}
 


### PR DESCRIPTION
- use `python:3.8-slim` as base image
- install `protect-archiver` from wheel file generated by `poetry build` using `pip install`
- push images to `unifitoolbox/protect-archiver`
- final image size is around 220MB