### PR TITLE
Add UniFi UDM API Proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3'
+services:
+  unifi-udm-api-proxy:
+    image: silvenga/unifi-udm-api-proxy:1
+    environment:
+      UDM__URI: ${UDM_URI}
+    restart: always


### PR DESCRIPTION
Add docker-compose configuration for UniFi UDM API Proxy from https://github.com/Silvenga/unifi-udm-api-proxy to add support for UDM-based Protect installations